### PR TITLE
dfom.htm and normalizations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
 	"recommendations": [
-		"ms-vscode.go"
+		"ms-vscode.go",
+		"ethan-reesor.vscode-go-test-adapter"
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,9 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "${workspaceFolder}",
+            "program": "${fileDirname}",
             "env": {},
-            "args": ["alive", "127.0.0.1"]
+            "args": []
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "mode": "auto",
             "program": "${workspaceFolder}",
             "env": {},
-            "args": ["alive", "example.com"]
+            "args": ["alive", "127.0.0.1"]
         }
     ]
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+The MIT License (MIT)
 
-Copyright (c) 2020 Andre Soares
+Copyright © 2020 Andre Soares
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ If the site returns any other status code, the check will fail.
 
 When the check succedes, it will be produce an exit code of `0`. Any failure will produce a difference exit code. Additionaly, there will always be a message in `STDOUT` when the check fails.
 #### Arguments
-* **`Base_URL`:** The base URL to use in the request. If _scheme_ is absent, `https://` will be used.
+* **`Base_URL`:** The base URL to use in the request. If _scheme_ is absent, `http` will be used for localhost or IPs. `https` is used otherwise.
 
 #### Flags
-* **`--path path`:** The path for the liveness endpoint (default `/_meta/alive`)
+* **`--path path`:** The path for the liveness endpoint (default `/dfom.htm`)
 
 ### Command `healthy`
 **`bphc healthy <Base_URL> [-v|--verbose] [--path path]`**
@@ -64,7 +64,7 @@ If not, the check will fail.
 
 When the check succedes, it will be produce an exit code of `0`. Any failure will produce a difference exit code. Additionaly, there will always be a message in `STDOUT` when the check fails.
 #### Arguments
-* **`Base_URL`:** The base URL to use in the request. If _scheme_ is absent, `https://` will be used.
+* **`Base_URL`:** The base URL to use in the request. If _scheme_ is absent, `http` will be used for localhost or IPs. `https` is used otherwise.
 
 #### Flags
 * **`--path path`:** The path for the healthcheck endpoint (default `/healthcheck`)

--- a/cmd/alive.go
+++ b/cmd/alive.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (

--- a/cmd/alive.go
+++ b/cmd/alive.go
@@ -45,5 +45,5 @@ var livenessPathFlag string
 
 func init() {
 	rootCmd.AddCommand(aliveCmd)
-	aliveCmd.Flags().StringVar(&livenessPathFlag, "path", "/_meta/alive", "The path for the liveness endpoint")
+	aliveCmd.Flags().StringVar(&livenessPathFlag, "path", "dfom.htm", "The path for the liveness endpoint")
 }

--- a/cmd/alive.go
+++ b/cmd/alive.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/BraspagDevelopers/bphc/lib"
 	"github.com/spf13/cobra"
@@ -37,10 +36,7 @@ var aliveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		baseUrl := args[0]
 		err := lib.LivenessCheck(baseUrl, livenessPathFlag, verboseFlag)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
-			os.Exit(1)
-		}
+		handle(err)
 		fmt.Printf("The site %s is alive.\n", baseUrl)
 	},
 }

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,13 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+)
+
+func handle(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/healthy.go
+++ b/cmd/healthy.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (

--- a/cmd/healthy.go
+++ b/cmd/healthy.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/BraspagDevelopers/bphc/lib"
 	"github.com/spf13/cobra"
@@ -37,10 +36,7 @@ var healthCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		baseUrl := args[0]
 		err := lib.HealthCheck(baseUrl, healthcheckPathFlag, verboseFlag)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
-			os.Exit(1)
-		}
+		handle(err)
 		fmt.Printf("The site %s is healthy.\n", baseUrl)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/go-resty/resty/v2 v2.3.0
 	github.com/spf13/cobra v1.0.0
+	github.com/stretchr/testify v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -63,6 +64,7 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -91,6 +93,7 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/lib/alive.go
+++ b/lib/alive.go
@@ -10,7 +10,7 @@ import (
 func LivenessCheck(base, path string, verbose bool) error {
 	url, err := makeurl(base, path)
 	if err != nil {
-		return fmt.Errorf("not a valid URL: %s", url)
+		return fmt.Errorf("invalid URL: %s/%s", base, path)
 	}
 	resp, err := resty.New().
 		SetDebug(verbose).

--- a/lib/alive.go
+++ b/lib/alive.go
@@ -2,26 +2,20 @@ package lib
 
 import (
 	"fmt"
-	"net/url"
-	"path"
 
 	"github.com/go-resty/resty/v2"
 )
 
 // LivenessCheck checks the liveness of an endpoint
-func LivenessCheck(baseURL, urlpath string, verbose bool) error {
-	fullURL, err := url.Parse(baseURL)
+func LivenessCheck(base, path string, verbose bool) error {
+	url, err := makeurl(base, path)
 	if err != nil {
-		return fmt.Errorf("not a valid URL: %s", fullURL)
-	}
-	fullURL.Path = path.Join(fullURL.Path, urlpath)
-	if fullURL.Scheme == "" {
-		fullURL.Scheme = "https"
+		return fmt.Errorf("not a valid URL: %s", url)
 	}
 	resp, err := resty.New().
 		SetDebug(verbose).
 		NewRequest().
-		Get(fullURL.String())
+		Get(url.String())
 	if err != nil {
 		return err
 	}

--- a/lib/healthy.go
+++ b/lib/healthy.go
@@ -3,29 +3,23 @@ package lib
 import (
 	"errors"
 	"fmt"
-	"net/url"
-	"path"
 	"strings"
 
 	"github.com/go-resty/resty/v2"
 )
 
 // HealthCheck checks the health of an endpoint
-func HealthCheck(baseURL, urlpath string, verbose bool) error {
-	fullURL, err := url.Parse(baseURL)
+func HealthCheck(base, path string, verbose bool) error {
+	url, err := makeurl(base, path)
 	if err != nil {
-		return fmt.Errorf("not a valid url: %s", fullURL)
-	}
-	fullURL.Path = path.Join(fullURL.Path, urlpath)
-	if fullURL.Scheme == "" {
-		fullURL.Scheme = "https"
+		return fmt.Errorf("not a valid URL: %s", url)
 	}
 	resp, err := resty.New().
 		SetDebug(verbose).
 		NewRequest().
 		SetResult(&healthCheckResponse{}).
 		SetError(&healthCheckResponse{}).
-		Get(fullURL.String())
+		Get(url.String())
 	if err != nil {
 		return err
 	}

--- a/lib/url.go
+++ b/lib/url.go
@@ -1,0 +1,32 @@
+package lib
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"path"
+)
+
+func normalize(u *url.URL) *url.URL {
+	h := u.Hostname()
+	ip := net.ParseIP(h)
+	if h == "localhost" || ip != nil {
+		if u.Scheme == "" {
+			u.Scheme = "http"
+		}
+	} else {
+		if u.Scheme == "" {
+			u.Scheme = "https"
+		}
+	}
+	return u
+}
+
+func makeurl(b, p string) (*url.URL, error) {
+	u, err := url.Parse(b)
+	if err != nil {
+		return nil, fmt.Errorf("not a valid URL: %s", b)
+	}
+	u.Path = path.Join(u.Path, p)
+	return normalize(u), nil
+}

--- a/lib/url.go
+++ b/lib/url.go
@@ -8,6 +8,11 @@ import (
 )
 
 func normalize(u *url.URL) *url.URL {
+
+	if strings.HasPrefix(u.Host, ":") {
+		u.Host = "localhost" + u.Host
+	}
+
 	h := u.Hostname()
 	ip := net.ParseIP(h)
 	if h == "localhost" || ip != nil {
@@ -24,23 +29,30 @@ func normalize(u *url.URL) *url.URL {
 
 func makeurl(b, p string) (*url.URL, error) {
 	if strings.HasPrefix(b, ":") {
-		b = "localhost" + b
+		return makeurl("localhost"+b, p)
 	}
+
+	_, _, err := net.SplitHostPort(b)
+	if err == nil {
+		return makeurl("http://"+b, p)
+	}
+
 	u, err := url.Parse(b)
 	if err != nil {
 		return nil, err
 	}
-	_, _, err = net.SplitHostPort(b)
-	if err == nil {
-		u = &url.URL{
-			Host: b,
-		}
-	}
+
 	if u.Host == "" {
 		u = &url.URL{
-			Host: b,
+			Scheme: "http",
+			Host:   b,
 		}
 	}
+
+	if u.Host == "" {
+		u.Host = "localhost"
+	}
+
 	u.Path = path.Join(u.Path, p)
 	return normalize(u), nil
 }

--- a/lib/url.go
+++ b/lib/url.go
@@ -1,10 +1,10 @@
 package lib
 
 import (
-	"fmt"
 	"net"
 	"net/url"
 	"path"
+	"strings"
 )
 
 func normalize(u *url.URL) *url.URL {
@@ -23,9 +23,23 @@ func normalize(u *url.URL) *url.URL {
 }
 
 func makeurl(b, p string) (*url.URL, error) {
+	if strings.HasPrefix(b, ":") {
+		b = "localhost" + b
+	}
 	u, err := url.Parse(b)
 	if err != nil {
-		return nil, fmt.Errorf("not a valid URL: %s", b)
+		return nil, err
+	}
+	_, _, err = net.SplitHostPort(b)
+	if err == nil {
+		u = &url.URL{
+			Host: b,
+		}
+	}
+	if u.Host == "" {
+		u = &url.URL{
+			Host: b,
+		}
 	}
 	u.Path = path.Join(u.Path, p)
 	return normalize(u), nil

--- a/lib/url_test.go
+++ b/lib/url_test.go
@@ -1,0 +1,44 @@
+package lib
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeUrl(t *testing.T) {
+	list := []struct {
+		url         string
+		path        string
+		expectedUrl string
+	}{
+		{":1234", "", "http://localhost:1234"},
+		{"localhost:1234", "", "http://localhost:1234"},
+		{"10.133.1.2:1234", "", "http://10.133.1.2:1234"},
+		{":1234", "/path", "http://localhost:1234/path"},
+		{"localhost:1234", "/path", "http://localhost:1234/path"},
+		{"10.133.1.2:1234", "/path", "http://10.133.1.2:1234/path"},
+
+		{"http://:1234", "", "http://localhost:1234"},
+		{"http://localhost:1234", "", "http://localhost:1234"},
+		{"http://10.133.1.2:1234", "", "http://10.133.1.2:1234"},
+		{"http://:1234", "/path", "http://localhost:1234/path"},
+		{"http://localhost:1234", "/path", "http://localhost:1234/path"},
+		{"http://10.133.1.2:1234", "/path", "http://10.133.1.2:1234/path"},
+
+		{"https://:1234", "", "https://localhost:1234"},
+		{"https://localhost:1234", "", "https://localhost:1234"},
+		{"https://10.133.1.2:1234", "", "https://10.133.1.2:1234"},
+		{"https://:1234", "/path", "https://localhost:1234/path"},
+		{"https://localhost:1234", "/path", "https://localhost:1234/path"},
+		{"https://10.133.1.2:1234", "/path", "https://10.133.1.2:1234/path"},
+	}
+	for i, tt := range list {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			actual, err := makeurl(tt.url, tt.path)
+			require.NoError(t, err)
+			require.EqualValues(t, tt.expectedUrl, actual.String())
+		})
+	}
+}

--- a/lib/url_test.go
+++ b/lib/url_test.go
@@ -13,6 +13,12 @@ func TestMakeUrl(t *testing.T) {
 		path        string
 		expectedUrl string
 	}{
+
+		{"localhost", "", "http://localhost"},
+		{"10.133.1.2", "", "http://10.133.1.2"},
+		{"localhost:1234", "/path", "http://localhost:1234/path"},
+		{"10.133.1.2:1234", "/path", "http://10.133.1.2:1234/path"},
+
 		{":1234", "", "http://localhost:1234"},
 		{"localhost:1234", "", "http://localhost:1234"},
 		{"10.133.1.2:1234", "", "http://10.133.1.2:1234"},

--- a/main.go
+++ b/main.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package main
 
 import "github.com/BraspagDevelopers/bphc/cmd"


### PR DESCRIPTION
- Change the default alive path to `/dfom.htm`
- Nomalize urls
  - when there is no host name but there is a port (`:1234`), `localhost` is assumed
  - when there is no scheme
    - when is `localhost` an some IP, use `http://`
    - elsewhere use `http://`
